### PR TITLE
fix deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
       - 'main'
-      - 'epic-1'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'master'
       - 'main'
+      - 'epic-1'
 
 jobs:
   deploy:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.2222</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -39,9 +39,9 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <pubRepoId>ossrh</pubRepoId>
-        <pubRepo>https://ossrh-staging-api.central.sonatype.com/content/repositories/releases</pubRepo>
+        <pubRepo>https://s01.oss.sonatype.org/content/repositories/releases</pubRepo>
         <pubSnapRepoId>ossrh</pubSnapRepoId>
-        <pubSnapRepo>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</pubSnapRepo>
+        <pubSnapRepo>https://s01.oss.sonatype.org/content/repositories/snapshots</pubSnapRepo>
         <pubStagingRepoId>ossrh</pubStagingRepoId>
         <pubStagingRepo>https://ossrh-staging-api.central.sonatype.com</pubStagingRepo>
         <checkstyle.config.path>
@@ -127,6 +127,24 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <version>1.7.1</version>
+                        <executions>
+                            <execution>
+                                <id>flatten</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>oss</flattenMode>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.22299</version>
+    <version>3.0.2230</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -99,6 +99,35 @@
                         </executions>
                     </plugin>
                 </plugins>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>flatten-maven-plugin</artifactId>
+                            <version>1.7.1</version>
+                            <executions>
+                                <execution>
+                                    <id>flatten</id>
+                                    <phase>process-resources</phase>
+                                    <goals>
+                                        <goal>flatten</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>flatten.clean</id>
+                                    <phase>clean</phase>
+                                    <goals>
+                                        <goal>clean</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <updatePomFile>true</updatePomFile>
+                                <flattenMode>oss</flattenMode>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2228</version>
+    <version>3.0.2229</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -42,15 +42,12 @@
         <pubRepo>https://s01.oss.sonatype.org/content/repositories/releases</pubRepo>
         <pubSnapRepoId>ossrh</pubSnapRepoId>
         <pubSnapRepo>https://s01.oss.sonatype.org/content/repositories/snapshots</pubSnapRepo>
-        <pubStagingRepoId>ossrh</pubStagingRepoId>
-        <pubStagingRepo>https://ossrh-staging-api.central.sonatype.com</pubStagingRepo>
         <checkstyle.config.path>
             https://raw.githubusercontent.com/valitydev/java-checkstyle-config/master/conf/valitydev_google_checkstyle.xml
         </checkstyle.config.path>
         <checkstyle.config.suppressions.path>
             https://raw.githubusercontent.com/valitydev/java-checkstyle-config/master/conf/checkstyle-suppressions.xml
         </checkstyle.config.suppressions.path>
-        <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
     </properties>
 
     <profiles>
@@ -95,18 +92,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>${pubStagingRepoId}</serverId>
-                            <nexusUrl>${pubStagingRepo}</nexusUrl>
-                            <autoReleaseAfterClose>${autoReleaseAfterClose}</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>${stagingProgressTimeoutMinutes}</stagingProgressTimeoutMinutes>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2229</version>
+    <version>3.0.22299</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -38,10 +38,6 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pubRepoId>ossrh</pubRepoId>
-        <pubRepo>https://s01.oss.sonatype.org/content/repositories/releases</pubRepo>
-        <pubSnapRepoId>ossrh</pubSnapRepoId>
-        <pubSnapRepo>https://s01.oss.sonatype.org/content/repositories/snapshots</pubSnapRepo>
         <checkstyle.config.path>
             https://raw.githubusercontent.com/valitydev/java-checkstyle-config/master/conf/valitydev_google_checkstyle.xml
         </checkstyle.config.path>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2227</version>
+    <version>3.0.2228</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -80,31 +80,6 @@
             </repositories>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>flatten-maven-plugin</artifactId>
-                        <version>1.7.1</version>
-                        <configuration>
-                            <updatePomFile>true</updatePomFile>
-                            <flattenMode>resolveCiFriendliesOnly</flattenMode>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>flatten</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>flatten</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>flatten.clean</id>
-                                <phase>clean</phase>
-                                <goals>
-                                    <goal>clean</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2223</version>
+    <version>3.0.2224</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -142,24 +142,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>flatten-maven-plugin</artifactId>
-                        <version>1.7.1</version>
-                        <executions>
-                            <execution>
-                                <id>flatten</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>flatten</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <updatePomFile>true</updatePomFile>
-                            <flattenMode>oss</flattenMode>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <version>3.6.0</version>
@@ -234,6 +216,24 @@
                                 <source>${maven.compiler.source}</source>
                                 <target>${maven.compiler.target}</target>
                                 <encoding>UTF-8</encoding>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>flatten-maven-plugin</artifactId>
+                            <version>1.7.1</version>
+                            <executions>
+                                <execution>
+                                    <id>flatten</id>
+                                    <phase>process-resources</phase>
+                                    <goals>
+                                        <goal>flatten</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <updatePomFile>true</updatePomFile>
+                                <flattenMode>oss</flattenMode>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -236,24 +236,6 @@
                                 <encoding>UTF-8</encoding>
                             </configuration>
                         </plugin>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>flatten-maven-plugin</artifactId>
-                            <version>1.7.1</version>
-                            <executions>
-                                <execution>
-                                    <id>flatten</id>
-                                    <phase>process-resources</phase>
-                                    <goals>
-                                        <goal>flatten</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <updatePomFile>true</updatePomFile>
-                                <flattenMode>oss</flattenMode>
-                            </configuration>
-                        </plugin>
                     </plugins>
                 </pluginManagement>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -53,30 +53,19 @@
     <profiles>
         <profile>
             <id>deploy</id>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>${pubSnapRepoId}</id>
-                    <url>${pubSnapRepo}</url>
-                </snapshotRepository>
-                <repository>
-                    <id>${pubRepoId}</id>
-                    <url>${pubRepo}</url>
-                </repository>
-            </distributionManagement>
-            <repositories>
-                <repository>
-                    <id>${pubSnapRepoId}</id>
-                    <url>${pubSnapRepo}</url>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>ossrh</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2225</version>
+    <version>3.0.2227</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -53,29 +53,6 @@
         <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.7.1</version>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                    <flattenMode>oss</flattenMode>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>deploy</id>
@@ -103,6 +80,31 @@
             </repositories>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <version>1.7.1</version>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>flatten</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>flatten.clean</id>
+                                <phase>clean</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2224</version>
+    <version>3.0.2225</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -52,6 +52,29 @@
         </checkstyle.config.suppressions.path>
         <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.7.1</version>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>oss</flattenMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>
@@ -216,24 +239,6 @@
                                 <source>${maven.compiler.source}</source>
                                 <target>${maven.compiler.target}</target>
                                 <encoding>UTF-8</encoding>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>flatten-maven-plugin</artifactId>
-                            <version>1.7.1</version>
-                            <executions>
-                                <execution>
-                                    <id>flatten</id>
-                                    <phase>process-resources</phase>
-                                    <goals>
-                                        <goal>flatten</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <updatePomFile>true</updatePomFile>
-                                <flattenMode>oss</flattenMode>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2230</version>
+    <version>3.0.2231</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -98,36 +98,32 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <version>1.7.1</version>
+                        <executions>
+                            <execution>
+                                <id>flatten</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>flatten.clean</id>
+                                <phase>clean</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                        </configuration>
+                    </plugin>
                 </plugins>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>flatten-maven-plugin</artifactId>
-                            <version>1.7.1</version>
-                            <executions>
-                                <execution>
-                                    <id>flatten</id>
-                                    <phase>process-resources</phase>
-                                    <goals>
-                                        <goal>flatten</goal>
-                                    </goals>
-                                </execution>
-                                <execution>
-                                    <id>flatten.clean</id>
-                                    <phase>clean</phase>
-                                    <goals>
-                                        <goal>clean</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <updatePomFile>true</updatePomFile>
-                                <flattenMode>oss</flattenMode>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
             </build>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2231</version>
+    <version>3.0.3</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>library-parent-pom</artifactId>
-    <version>3.0.2222</version>
+    <version>3.0.2223</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>
@@ -128,6 +128,19 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>common</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>env.MVN_PROFILE</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>flatten-maven-plugin</artifactId>
@@ -146,19 +159,6 @@
                             <flattenMode>oss</flattenMode>
                         </configuration>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>common</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <property>
-                    <name>env.MVN_PROFILE</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -234,6 +234,24 @@
                                 <source>${maven.compiler.source}</source>
                                 <target>${maven.compiler.target}</target>
                                 <encoding>UTF-8</encoding>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>flatten-maven-plugin</artifactId>
+                            <version>1.7.1</version>
+                            <executions>
+                                <execution>
+                                    <id>flatten</id>
+                                    <phase>process-resources</phase>
+                                    <goals>
+                                        <goal>flatten</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <updatePomFile>true</updatePomFile>
+                                <flattenMode>oss</flattenMode>
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION
нюансы
1) публикация
гпт указывал что при миграции на централ портал стейджинг плагин не нужен и достаточно указать правильный урл сонатайпа и distributionManagement и все само будет работать, но у меня не получилось, кидает 504. 
другой вариант был взять офф плагин сонатайпа https://central.sonatype.org/publish/publish-portal-maven/#wait-for-publishing который по идее под капотом должен сам все корректно резолвить урлы и настройки, надо указать только айди settings.xml для репозитория, и это сработало
2) валидация
на данном этапе парент собирался корректно а вот дамзель нет. писал ошибку в лог

Deployment d6f761c2-f70a-4109-bd94-c3b113ec4f8e failed
pkg:maven/dev.vality/damsel@SNAPSHOT:
 - The version cannot be a SNAPSHOT
 - POM matching coordinates not found in entries
 - Sources must be provided but not found in entries
 - Javadocs must be provided but not found in entries
 
тут пришел в выводу что без flatten-maven-plugin не обойтись из за более строгих правил валидации при публикации. пытался подобрать сетап чтоб в наследниках по минимуму изменений завозить. 
проблематика тут была в том что для парента флаттен не нужен (тк и так деполится) , он нужен только для наследников. но если указать флатен в паренте то он трет много нужной инфы и из за этого в итоге наследник (дамзель) не собирается. 
был варик поместить флатен в pluginManagement и вызывать в наследниках как зависимостях - это работает но это коряво, тк можно тогда напрямую в наследниках вызывать этот плагин. 
то есть проблема что если флатен в паранте он оттуда трет инфу которая нужна позже в наследниках.
но на удачу помогла и решила вопрос опция <flattenMode>resolveCiFriendliesOnly</flattenMode> которая генерирует минимум модификаций парента (только заполняет переменные помника) 
тогда получается плагин и парент не дамажит и он остается валидный для наследников и для наследников делает минимум изменений который пропускает валидация при публикации